### PR TITLE
DTC report ver2 (offline tiles)

### DIFF
--- a/dtc-systems/dtc_report/organize_tiles.py
+++ b/dtc-systems/dtc_report/organize_tiles.py
@@ -1,43 +1,56 @@
 import os
 import shutil
+import argparse
 
-# --- Configuration ---
-source_folder = 'downloaded_tiles'
-destination_folder = 'tiles'
-# ---------------------
 
-if not os.path.exists(source_folder):
-    print(f"Error: Source folder '{source_folder}' not found.")
-    exit()
+def main():
+    parser = argparse.ArgumentParser(description='Convert downloaded images to tiles structure')
+    parser.add_argument('--src', required=True, help='Impot directory, where new tiles are downloaded')
+    parser.add_argument('--tiles-root', help='root directory where is the tree of tiles stored',
+                        default='tiles')
+    args = parser.parse_args()
 
-print(f"Starting tile organization from '{source_folder}'...")
+    # --- Configuration ---
+    source_folder = args.src
+    destination_folder = args.tiles_root
+    # ---------------------
 
-# Loop through all files in the source folder
-for filename in os.listdir(source_folder):
-    # Skip directories or files with extensions
-    if os.path.isdir(os.path.join(source_folder, filename)) or '.' in filename:
-        continue
+    if not os.path.exists(source_folder):
+        print(f"Error: Source folder '{source_folder}' not found.")
+        exit()
 
-    if '(' in filename:  # some strange PNG bits
-        continue
+    print(f"Starting tile organization from '{source_folder}'...")
 
-    # Split the name by the hyphen, e.g., "18-70083-106019" -> ["18", "70083", "106019"]
-    parts = filename.split('-')
+    # Loop through all files in the source folder
+    for filename in os.listdir(source_folder):
+        # Skip directories or files with extensions
+        if os.path.isdir(os.path.join(source_folder, filename)) or '.' in filename:
+            continue
 
-    if len(parts) == 3:
-        z, x, y = parts
-        
-        # Create the target directory path, e.g., "tiles/18/70083"
-        target_dir = os.path.join(destination_folder, z, x)
-        os.makedirs(target_dir, exist_ok=True)
-        
-        # Define the source and destination paths for the file
-        source_path = os.path.join(source_folder, filename)
-        # Add the .jpeg extension to the destination filename
-        destination_path = os.path.join(target_dir, y + '.jpeg')
-        
-        # Move and rename the file
-        shutil.copy(source_path, destination_path)
-        print(f"Copy {filename} -> {destination_path}")
+        if '(' in filename:  # some strange PNG bits
+            continue
 
-print("Tile organization complete.")
+        # Split the name by the hyphen, e.g., "18-70083-106019" -> ["18", "70083", "106019"]
+        parts = filename.split('-')
+
+        if len(parts) == 3:
+            z, x, y = parts
+
+            # Create the target directory path, e.g., "tiles/18/70083"
+            target_dir = os.path.join(destination_folder, z, x)
+            os.makedirs(target_dir, exist_ok=True)
+
+            # Define the source and destination paths for the file
+            source_path = os.path.join(source_folder, filename)
+            # Add the .jpeg extension to the destination filename
+            destination_path = os.path.join(target_dir, y + '.jpeg')
+
+            # Move and rename the file
+            shutil.copy(source_path, destination_path)
+            print(f"Copy {filename} -> {destination_path}")
+
+    print("Tile organization complete.")
+
+
+if __name__ == "__main__":
+    main()

--- a/dtc-systems/dtc_report/organize_tiles.py
+++ b/dtc-systems/dtc_report/organize_tiles.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+
+# --- Configuration ---
+source_folder = 'downloaded_tiles'
+destination_folder = 'tiles'
+# ---------------------
+
+if not os.path.exists(source_folder):
+    print(f"Error: Source folder '{source_folder}' not found.")
+    exit()
+
+print(f"Starting tile organization from '{source_folder}'...")
+
+# Loop through all files in the source folder
+for filename in os.listdir(source_folder):
+    # Skip directories or files with extensions
+    if os.path.isdir(os.path.join(source_folder, filename)) or '.' in filename:
+        continue
+
+    if '(' in filename:  # some strange PNG bits
+        continue
+
+    # Split the name by the hyphen, e.g., "18-70083-106019" -> ["18", "70083", "106019"]
+    parts = filename.split('-')
+
+    if len(parts) == 3:
+        z, x, y = parts
+        
+        # Create the target directory path, e.g., "tiles/18/70083"
+        target_dir = os.path.join(destination_folder, z, x)
+        os.makedirs(target_dir, exist_ok=True)
+        
+        # Define the source and destination paths for the file
+        source_path = os.path.join(source_folder, filename)
+        # Add the .jpeg extension to the destination filename
+        destination_path = os.path.join(target_dir, y + '.jpeg')
+        
+        # Move and rename the file
+        shutil.copy(source_path, destination_path)
+        print(f"Copy {filename} -> {destination_path}")
+
+print("Tile organization complete.")

--- a/dtc-systems/dtc_report/templates/template.html
+++ b/dtc-systems/dtc_report/templates/template.html
@@ -142,7 +142,7 @@
             ? [firstLocatedReport.location.latitude, firstLocatedReport.location.longitude]
             : [32.50434376, -83.75090537];
 
-        const map = L.map('map').setView(initialCoords, 20);
+        const map = L.map('map').setView(initialCoords, 19);
 
         // 3. Add the tile layer (the map background)
         L.tileLayer('tiles/{z}/{x}/{y}.jpeg', { // <-- Make sure the extension is .jpeg

--- a/dtc-systems/dtc_report/templates/template.html
+++ b/dtc-systems/dtc_report/templates/template.html
@@ -142,14 +142,14 @@
             ? [firstLocatedReport.location.latitude, firstLocatedReport.location.longitude]
             : [32.50434376, -83.75090537];
 
-        const map = L.map('map').setView(initialCoords, 18);
+        const map = L.map('map').setView(initialCoords, 20);
 
         // 3. Add the tile layer (the map background)
         L.tileLayer('tiles/{z}/{x}/{y}.jpeg', { // <-- Make sure the extension is .jpeg
             attribution: 'Map data &copy; OpenStreetMap contributors',
             // You can set min/max zoom based on the tiles you have
             minZoom: 18,
-            maxZoom: 18
+            maxZoom: 20
         }).addTo(map);
 
         // 4. Loop through the data and add custom markers

--- a/dtc-systems/dtc_report/templates/template.html
+++ b/dtc-systems/dtc_report/templates/template.html
@@ -145,8 +145,11 @@
         const map = L.map('map').setView(initialCoords, 18);
 
         // 3. Add the tile layer (the map background)
-        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-            attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        L.tileLayer('tiles/{z}/{x}/{y}.jpeg', { // <-- Make sure the extension is .jpeg
+            attribution: 'Map data &copy; OpenStreetMap contributors',
+            // You can set min/max zoom based on the tiles you have
+            minZoom: 18,
+            maxZoom: 18
         }).addTo(map);
 
         // 4. Loop through the data and add custom markers


### PR DESCRIPTION
This is probably the "final" version for now - it runs offline with previously downloaded files. For example in U.S. it will be here:
https://mapy.com/en/letecka?x=-83.75090537&y=32.50434376&z=18
Open it in Chrome or Chromium (Firefox behaves differently!), save whole webpage and then run
```
python organize_tiles.py --src ~/Downloads/chromium-us-18_files/
```
It will copy and rename detected tiles. This can be repeated for multiple zooms and shifts. Result looks like this:
![casualty-reports](https://github.com/user-attachments/assets/092f29e5-ddd7-44d2-9543-0be2f901f5e1)
